### PR TITLE
Adjust EOF check to account for possible over-reading

### DIFF
--- a/src/StringStream.php
+++ b/src/StringStream.php
@@ -109,7 +109,7 @@ class StringStream implements StreamInterface
      */
     public function eof(): bool
     {
-        return $this->pointer === $this->length;
+        return $this->pointer >= $this->length;
     }
 
     /**

--- a/tests/StringStreamTest.php
+++ b/tests/StringStreamTest.php
@@ -207,4 +207,13 @@ class StringStreamTest extends TestCase
         $this->expectExceptionMessage("You cannot call `getContents' on this stream because it's closed.");
         $stringStream->getContents();
     }
+
+    public function testEOFAfterOverReading(): void
+    {
+        $stringStream = new StringStream('hello world');
+        self::assertFalse($stringStream->eof());
+        $text = $stringStream->read(1048576);
+        self::assertSame('hello world', $text);
+        self::assertTrue($stringStream->eof());
+    }
 }


### PR DESCRIPTION
It's possible for the stream to be "over-read", which moves the internal pointer way past the length of the data.  As things stand, the `eof()` check will return `false` in such cases because `$pointer !== $length`.  This becomes problematic when used in a loop, e.g.

```php
while (!$stream->eof()) {
    hash_update($ctx, $stream->read(1048576));
}
```

The above is from guzzlehttp/psr7's `Utils::hash()` function, which is used by the `SignatureV4` class of AWS's PHP SDK.

This PR changes the check from `$pointer === $length` to `$pointer >= $length` to account for possible over-reading.